### PR TITLE
Task.yml run path was pointing to different task output

### DIFF
--- a/run-maven-itests-cache/task.yml
+++ b/run-maven-itests-cache/task.yml
@@ -25,4 +25,4 @@ caches:
 - path: project/.m2repository
 
 run:
-  path: pipeline-tasks/run-maven-itests/task.sh
+  path: pipeline-tasks/run-maven-itests-cache/task.sh


### PR DESCRIPTION
It looks like the maven itests cache task was pointing to the non-cache task
