### PR TITLE
Run mvn failsafe itest goals directly

### DIFF
--- a/run-maven-failsafe-semver-cache/task.sh
+++ b/run-maven-failsafe-semver-cache/task.sh
@@ -1,0 +1,21 @@
+#!/bin/ash
+#
+# All UPERCASE variables are provided externally from this script
+
+set -eu
+set -o pipefail
+
+version=$(cat version/version)
+
+cd project
+
+args="-Drevision=$version"
+[ -n "$MAVEN_PROJECTS" ] && args="$args --projects $MAVEN_PROJECTS"
+[ -n "$MAVEN_REPO_MIRROR" ] && args="$args -Drepository.url=$MAVEN_REPO_MIRROR";
+[ -n "$MAVEN_REPO_USERNAME" ] && args="$args -Drepository.username=$MAVEN_REPO_USERNAME";
+[ -n "$MAVEN_REPO_PASSWORD" ] && args="$args -Drepository.password=$MAVEN_REPO_PASSWORD";
+[ "true" = "$MAVEN_REPO_CACHE_ENABLE" ] && args="$args -Dmaven.repo.local=$PWD/.m2repository"
+
+./mvnw test-compile failsafe:integration-test failsafe:verify $args
+
+cd ..

--- a/run-maven-failsafe-semver-cache/task.yml
+++ b/run-maven-failsafe-semver-cache/task.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: openjdk
+    tag: '8-jdk-alpine'
+
+params:
+  MAVEN_OPTS:
+  MAVEN_CONFIG:
+  MAVEN_PROJECTS:
+  MAVEN_REPO_MIRROR:
+  MAVEN_REPO_USERNAME:
+  MAVEN_REPO_PASSWORD:
+  MAVEN_REPO_CACHE_ENABLE: false # set this to true in your pipeline to cache your repo on the worker
+
+inputs:
+- name: version
+- name: pipeline-tasks
+- name: project
+
+caches:
+- path: project/.m2repository
+
+run:
+  path: pipeline-tasks/run-maven-failsafe-semver-cache/task.sh


### PR DESCRIPTION
I was looking for a way to _only_ run our itests without running our unit tests.

(And even if I did want to run both the unit tests and itests in one task, unfortunately, unless we added failsafe configuration to the pom.xml, `./mvnw verify` wasn't triggering our projects' itests-- only the unit tests. [I believe the problem is documented in this github issue](https://github.com/spring-projects/spring-boot/issues/6254))

Definitely let me know if you have any questions/suggestions/concerns.