### PR TITLE
Create surefire-report.html

### DIFF
--- a/build-maven-surefire-report-semver-cache/task.sh
+++ b/build-maven-surefire-report-semver-cache/task.sh
@@ -1,0 +1,25 @@
+#!/bin/ash
+# This script assumes Maven Wrapper is used with Maven v3.5.0 or higher.
+#   see: https://maven.apache.org/maven-ci-friendly.html
+#
+# All UPERCASE variables are provided externally from this script
+
+set -eu
+set -o pipefail
+
+version=$(cat version/version)
+
+cd project
+
+args="-Drevision=$version"
+[ -n "$MAVEN_PROJECTS" ] && args="$args --projects $MAVEN_PROJECTS"
+[ -n "$MAVEN_REPO_MIRROR" ] && args="$args -Drepository.url=$MAVEN_REPO_MIRROR";
+[ -n "$MAVEN_REPO_USERNAME" ] && args="$args -Drepository.username=$MAVEN_REPO_USERNAME";
+[ -n "$MAVEN_REPO_PASSWORD" ] && args="$args -Drepository.password=$MAVEN_REPO_PASSWORD";
+[ "true" = "$MAVEN_REPO_CACHE_ENABLE" ] && args="$args -Dmaven.repo.local=$PWD/.m2repository"
+
+./mvnw surefire-report:report $args
+
+cd ..
+
+cp -R project/target/site/surefire-report.html task-output/.

--- a/build-maven-surefire-report-semver-cache/task.yml
+++ b/build-maven-surefire-report-semver-cache/task.yml
@@ -1,0 +1,32 @@
+# Builds a maven project and copies the artifact to the task-output folder
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: openjdk
+    tag: '8-jdk-alpine'
+
+params:
+  MAVEN_OPTS:
+  MAVEN_CONFIG:
+  MAVEN_PROJECTS:
+  MAVEN_REPO_MIRROR:
+  MAVEN_REPO_USERNAME:
+  MAVEN_REPO_PASSWORD:
+  MAVEN_REPO_CACHE_ENABLE: false # set this to true in your pipeline to cache your repo on the worker
+
+inputs:
+- name: pipeline-tasks
+- name: project
+- name: version
+
+caches:
+- path: project/.m2repository
+
+outputs:
+- name: task-output
+
+run:
+  path: pipeline-tasks/build-maven-surefire-report-semver-cache/task.sh


### PR DESCRIPTION
This outputs the standalone raw surefire-report.html without any CSS or the like.

We use this task to include a (basic & unstyled) test report as a part of `github-release`