### PR TITLE
Task to build yarn projects

### DIFF
--- a/build-yarn/README.md
+++ b/build-yarn/README.md
@@ -1,0 +1,27 @@
+# build-yarn
+
+This task is opinionated on how your `package.json` should be structured.
+
+Only three scripts are called:
+```
+yarn install
+yarn test
+yarn bundle -p --output-path=../js-assets/
+```
+
+These scripts are treated as the interface into all webapp projects passed through the pipeline. This allows developers to include implementation details specific to each project, while the pipeline can remain general enough to serve multiple projects.
+
+Therefore, it's recommended you structure `test` with things such as linting, and `bundle` with whatever you feel is necessary to build your project.
+
+For example, notice how `test` calls other scripts which are included in the `package.json`:
+```json
+"scripts": {
+  "test": "jest --config ./jest/jest.config.json && yarn run lint && yarn run stylelint",
+  "updateSnapshots": "jest -u --config ./jest/jest.config.json",
+  "lint": "eslint src/main/resources/assets/**/*.js",
+  "stylelint": "stylelint src/main/resources/assets/**/*.less",
+  "bundle": "rimraf ./target/classes/static && webpack --bail",
+  "bundle-dev": "yarn run bundle --devtool source-map",
+  "watch": "nodemon --exec yarn run bundle-dev --watch src/main/resources/assets -L"
+},
+```

--- a/build-yarn/task.sh
+++ b/build-yarn/task.sh
@@ -1,0 +1,18 @@
+#!/bin/ash
+#
+# All UPERCASE variables are provided externally from this script
+
+set -eu
+set -o pipefail
+[ 'true' = "${DEBUG:-}" ] && set -x
+
+cd project
+
+if [ ! -f "./package.json" ]; then
+  echo "package.json not found in root dir: exiting gracefully."
+  exit 0;
+fi
+
+yarn install
+yarn test
+yarn bundle -p --output-path=../js-assets/

--- a/build-yarn/task.yml
+++ b/build-yarn/task.yml
@@ -1,0 +1,26 @@
+# Builds a yarn project and copies build to the task-output folder
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: mhart/alpine-node
+    tag: 'latest'
+
+params:
+  DEBUG: false
+
+inputs:
+- name: pipeline-tasks
+- name: project
+
+caches:
+- path: project/node
+- path: project/node_modules
+
+outputs:
+- name: js-assets
+
+run:
+  path: pipeline-tasks/build-yarn/task.sh


### PR DESCRIPTION
Includes a readme on how the task should be used. This can be removed/changed if you prefer.

Notice this bails out with `exit 0` if no `package.json` if present. I can remove/make it conditional if you'd like. We added this shortcircuit so we could make our pipelines slightly more general for apps that don't have any JS in the frontend.